### PR TITLE
Append story ID rather than prepending it

### DIFF
--- a/lib/internal/ask.js
+++ b/lib/internal/ask.js
@@ -208,7 +208,7 @@ var ask = {
 
 		rl.question("branch name (" + suggestedName + "): ", function (answer) {
 			var name = answer.trim() || suggestedName;
-			name = story.id + '-' + name;
+			name = name + '-' + story.id;
 			rl.close();
 			callback(null, name);
 		})


### PR DESCRIPTION
Makes it much easier to tab-complete the correct branch name since
you don't have to match the initial story ID.
