### PR TITLE
Preserve commit history on merge

### DIFF
--- a/lib/internal/git.js
+++ b/lib/internal/git.js
@@ -128,13 +128,34 @@ var git = {
 						callback(new Error("Could not read Git repo metadata:", stderr.toString()));
 					}
 					else {
-						var gitDir = path.join(stdout.toString(), ".git"),
-							squashMsgFile = path.join(gitDir, "SQUASH_MSG"),
-							squashMsg = fs.readFileSync(squashMsgFile, {encoding: 'utf8'});
-						message = message + "\n\n" + squashMsg;
-						fs.writeFileSync(squashMsgFile, message, {encoding: 'utf8'});
-						// At this point `SQUASH_MSG` contains all we want
-						exec('git commit -a --no-edit', function (err, stdout, stderr) {
+						var squashMsg;
+						try {
+							var gitDir = path.join(stdout.toString().trim(), ".git"),
+								messageFile = path.join(gitDir, "SQUASH_MSG");
+							try {
+								squashMsg = fs.readFileSync(messageFile, {encoding: 'utf8'});
+							}
+							catch (e) {
+								try {
+									messageFile = path.join(gitDir, "MERGE_MSG");
+									squashMsg = fs.readFileSync(messageFile, {encoding: 'utf8'});
+								}
+								catch (e) {
+									// do nothing
+								}
+							}
+							if (squashMsg) {
+								message = message + "\n\n" + squashMsg;
+							}
+							fs.writeFileSync(messageFile, message, {encoding: 'utf8'});
+						}
+						catch (e) {
+							// OK, that didn't work -- continue with the regular message
+						}
+						// At this point `SQUASH_MSG` contains all we want,
+						// if it exists; otherwise just use the message
+						var cmd = (squashMsg) ? 'git commit -a --no-edit' : 'git commit -am "' + message + '"';
+						exec(cmd, function (err, stdout, stderr) {
 							if(err) {
 								callback(new Error("Could not commit squashed merge: " + stderr.toString()));
 							}


### PR DESCRIPTION
Simply squashing deletes any commit history -- we want to preserve anything that may be useful. 

To be perfect, this _does_ require the developer to clean up their history before `git finish`, but that's good practice anyway.
