### PR TITLE
Escape double quotes too

### DIFF
--- a/lib/internal/ask.js
+++ b/lib/internal/ask.js
@@ -202,7 +202,7 @@ var ask = {
 		});
 
 		var suggestedName = story.name.replace(/\s+/g, '-')
-			.replace(/[!\'\"]/g, '')
+			.replace(/[!\'\"\)\(\:<\>)]/g, '')
 			.toLowerCase();
 		var split = suggestedName.split('-')
 		var completions = split.map(function (segment, index) {

--- a/lib/internal/git.js
+++ b/lib/internal/git.js
@@ -28,7 +28,7 @@ var git = {
 	//makes new branch and pushes to origin
 	newBranch: function (name, callback) {
 		//remove a few illegal git characters
-		name = name.replace(/\"|\'|\)|\(|\:|<|\>/g, '').replace(/\!/g, '');
+		name = name.replace(/[!\'\"\)\(\:<\>)]/g, '');
 		exec('git checkout -b ' + name, function (err, stdout, stderr) {
 			if(err) {
 				callback(new Error(stderr));

--- a/lib/internal/git.js
+++ b/lib/internal/git.js
@@ -28,7 +28,7 @@ var git = {
 	//makes new branch and pushes to origin
 	newBranch: function (name, callback) {
 		//remove a few illegal git characters
-		name = name.replace(/\'/g, '').replace(/\!/g, '');
+		name = name.replace(/\'\"/g, '').replace(/\!/g, '');
 		exec('git checkout -b ' + name, function (err, stdout, stderr) {
 			if(err) {
 				callback(new Error(stderr));
@@ -64,7 +64,7 @@ var git = {
 	},
 	deleteLocalBranch: function(opts, callback) {
 		var validTypes = ["-d", "-D"];
-		
+
 		var branch = undefined;
 		var type = "-d";
 		if(typeof opts == "string"){
@@ -159,7 +159,7 @@ var git = {
 
 	/* merges branch in to this one, squashing, committing w/ message*/
 	merge: function (branch, message, callback) {
-		
+
 		exec('git merge --squash --ff-only ' + branch, function (err, stdout, stderr) {
 			if(err) {
 				callback(new Error("Could not merge trivially: " + stderr.toString()));
@@ -208,7 +208,7 @@ var git = {
 							// At this point `SQUASH_MSG` contains all we want,
 							// if it exists; otherwise just use the message
 							var cmd = (squashMsg) ? 'git commit -a --no-edit' : 'git commit -am "' + message + '"';
-								
+
 							exec(cmd, function (err, stdout, stderr) {
 								if(err) {
 									callback(new Error("Could not commit squashed merge: " + stderr.toString()));

--- a/lib/internal/git.js
+++ b/lib/internal/git.js
@@ -28,7 +28,7 @@ var git = {
 	//makes new branch and pushes to origin
 	newBranch: function (name, callback) {
 		//remove a few illegal git characters
-		name = name.replace(/\'\"/g, '').replace(/\!/g, '');
+		name = name.replace(/\"|\'|\)|\(|\:|<|\>/g, '').replace(/\!/g, '');
 		exec('git checkout -b ' + name, function (err, stdout, stderr) {
 			if(err) {
 				callback(new Error(stderr));


### PR DESCRIPTION
Pivotal stories often have quotes in the name or description (to identify pages, specific ui elements, or concepts) that need to be able to be pushed to git. 

This escapes double quotes along with single quotes.